### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/luwoehrldemo/b1474950-c6f1-4427-951a-77eb0e9c5cbc/0bb6ca90-9d83-427f-afd6-2c34f275cfaa/_apis/work/boardbadge/578e30c5-c57f-4093-bb07-35e4a2a07f38)](https://dev.azure.com/luwoehrldemo/b1474950-c6f1-4427-951a-77eb0e9c5cbc/_boards/board/t/0bb6ca90-9d83-427f-afd6-2c34f275cfaa/Microsoft.EpicCategory)
 Demonstrated to usage of templates for sharing variables
 
 Uses the following Git repositories:


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#598](https://dev.azure.com/luwoehrldemo/b1474950-c6f1-4427-951a-77eb0e9c5cbc/_workitems/edit/598). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.